### PR TITLE
update monitoring node.js client to 2.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Compute Engine Autoscaling Using Stackdriver Custom Metrics
-This code is an example reference implementation for the Compute Engine Autoscaling Using Stackdriver Custom Metrics [tutorial](https://cloud.google.com/solutions/autoscaling-instance-group-with-custom-stackdrivers-metric) on the Google Cloud solutions site.
+# Compute Engine autoscaling using custom Cloud Monitoring metric
+This code is an example reference implementation for the Compute Engine Autoscaling using custom Cloud Monitoring metric [tutorial](https://cloud.google.com/architecture/autoscaling-instance-group-with-custom-stackdrivers-metric) on the Google Cloud solutions site.
 
 # Components
 * writeToCustomMetric.js - a NodeJS app that uses the Google Cloud SDK client to write a custom monitoring metric 
@@ -8,4 +8,4 @@ This code is an example reference implementation for the Compute Engine Autoscal
 
 
 # Installation
-1. Follow the detailed steps in the Compute Engine Autoscaling Using Stackdriver Custom Metrics [tutorial](https://cloud.google.com/solutions/autoscaling-instance-group-with-custom-stackdrivers-metric) to configure and deploy the code
+1. Follow the detailed steps in the Compute Engine Autoscaling Using Stackdriver Custom Metrics [tutorial](https://cloud.google.com/architecture/autoscaling-instance-group-with-custom-stackdrivers-metric) to configure and deploy the code

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "ava -T 20s --verbose test/*.test.js"
   },
   "dependencies": {
-    "@google-cloud/monitoring": "0.3.0"
+    "@google-cloud/monitoring": "2.3.5"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.1.2",

--- a/writeToCustomMetric.js
+++ b/writeToCustomMetric.js
@@ -20,7 +20,7 @@ const Monitoring = require('@google-cloud/monitoring');
 // import the configuration
 const config = require('./config.json');
 // Instantiates a monitoring client
-const client = Monitoring.v3.metric();
+const client = new Monitoring.MetricServiceClient();
 // gets a random integer between a [min - max-1]
 function getRandomInt(min, max) {
   min = Math.ceil(min);


### PR DESCRIPTION
The [tutorial](https://cloud.google.com/architecture/autoscaling-instance-group-with-custom-stackdrivers-metric) no longer works with stackdriver monitoring node.js client v0.3.0. Updated to newest version [2.3.5](https://www.npmjs.com/package/@google-cloud/monitoring/v/2.3.5) and confirmed this to work again.